### PR TITLE
composer: remove defaults

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,5 @@
 			"Regulus\\Formation\\": "src/",
 			"Regulus\\Formation\\Models\\": "src/models/"
 		}
-	},
-	"minimum-stability": "stable"
+	}
 }


### PR DESCRIPTION
It's `stable` by default: https://getcomposer.org/doc/04-schema.md#minimum-stability